### PR TITLE
Print error on authentication failure (401)

### DIFF
--- a/src/jenkins.coffee
+++ b/src/jenkins.coffee
@@ -80,6 +80,8 @@ jenkinsDescribe = (msg) ->
     req.get() (err, res, body) ->
         if err
           msg.send "Jenkins says: #{err}"
+        else if res.statusCode == 401
+          msg.send "Invalid credentials"
         else
           response = ""
           try
@@ -127,6 +129,8 @@ jenkinsDescribe = (msg) ->
             req.get() (err, res, body) ->
                 if err
                   msg.send "Jenkins says: #{err}"
+                else if res.statusCode == 401
+                  msg.send "Invalid credentials"
                 else
                   response = ""
                   try
@@ -159,6 +163,8 @@ jenkinsLast = (msg) ->
     req.get() (err, res, body) ->
         if err
           msg.send "Jenkins says: #{err}"
+        else if res.statusCode == 401
+          msg.send "Invalid credentials"
         else
           response = ""
           try
@@ -186,6 +192,8 @@ jenkinsList = (msg) ->
         response = ""
         if err
           msg.send "Jenkins says: #{err}"
+        else if res.statusCode == 401
+          msg.send "Invalid credentials"
         else
           try
             content = JSON.parse(body)


### PR DESCRIPTION
When jenkins returns a 401 it gives a HTML response, which JSON.parse throws on, which in turn causes the very readable error message:

```
SyntaxError: Unexpected token <
```

Now it should instead read:

```
Invalid credentials
```
