### PR TITLE
Able to be specified the HUBOT_JENKINS_DISPLAY_URL

### DIFF
--- a/src/jenkins.coffee
+++ b/src/jenkins.coffee
@@ -7,6 +7,7 @@
 # Configuration:
 #   HUBOT_JENKINS_URL
 #   HUBOT_JENKINS_AUTH
+#   HUBOT_JENKINS_DISPLAY_URL
 #
 #   Auth should be in the "user:password" format.
 #
@@ -58,7 +59,10 @@ jenkinsBuild = (msg, buildWithEmptyParameters) ->
         if err
           msg.reply "Jenkins says: #{err}"
         else if 200 <= res.statusCode < 400 # Or, not an error code.
-          msg.reply "(#{res.statusCode}) Build started for #{unescapedJob} #{url}/job/#{job}"
+          u = url
+          if process.env.HUBOT_JENKINS_DISPLAY_URL
+            u = process.env.HUBOT_JENKINS_DISPLAY_URL
+          msg.reply "(#{res.statusCode}) Build started for #{job} #{u}/job/#{job}"
         else if 400 == res.statusCode
           jenkinsBuild(msg, true)
         else


### PR DESCRIPTION
## Abst
If the HUBOT_JENKINS_DISPLAY_URL environment variable is set, it can be displayed, when the build succeeds.

## How to use
Below commands

* Hubot start

```
export HUBOT_SLACK_TOKEN=xoxb-xxxxxxxxxxxxxxxxxxxxxxxxxxx && \
export HUBOT_JENKINS_URL=http://localhost:8080 && \
export HUBOT_JENKINS_AUTH=jenkinsu:jenkinsp && \
export HUBOT_JENKINS_DISPLAY_URL=http://192.168.100.105:8080 && \
./bin/hubot --adapter slack
```

* Command on Slack

```
@test-bot jenkins build test
```

* Result on Slack

```
@kakakikikeke-fork: (201) Build started for test http://192.168.100.105:8080/job/test
```

192.168.100.105 instead of localhost will preferentially be displayed.